### PR TITLE
Stop pretty printing json

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -31,7 +31,7 @@ def api_read(request):
     od = OrderedDict()
     od['hello'] = 'World'
     od['oauth2'] = True
-    return HttpResponse(json.dumps(od, indent=4),
+    return HttpResponse(json.dumps(od),
                         content_type='application/json')
 
 # Example in curl calling this write API
@@ -72,14 +72,14 @@ def api_write(request):
             response['status'] = 'Error'
             response['message'] = 'Write Failed.'
             response['errors'] = errors
-            return HttpResponse(json.dumps(response, indent=4),
+            return HttpResponse(json.dumps(response),
                                 content_type='application/json')
         # a valid JSON object was provided.
-        return HttpResponse(json.dumps(j, indent=4),
+        return HttpResponse(json.dumps(j),
                             content_type='application/json')
     # this is a GET
     response = OrderedDict()
     response['code'] = 200
     response['message'] = 'POST JSON as the body of the request to this URL.'
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         content_type='application/json')

--- a/apps/capabilities/management/commands/create_blue_button_scopes.py
+++ b/apps/capabilities/management/commands/create_blue_button_scopes.py
@@ -37,7 +37,7 @@ def create_userinfo_capability(group,
                                                title=title,
                                                description=description,
                                                slug=scope_string,
-                                               protected_resources=json.dumps(pr, indent=4))
+                                               protected_resources=json.dumps(pr))
         print("%s - %s created." % (c.slug, c.title))
     return c
 
@@ -59,7 +59,7 @@ def create_patient_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               protected_resources=json.dumps(pr, indent=4))
+                                               protected_resources=json.dumps(pr))
         print("%s - %s created" % (c.slug, c.title))
     return c
 
@@ -80,7 +80,7 @@ def create_eob_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               protected_resources=json.dumps(pr, indent=4))
+                                               protected_resources=json.dumps(pr))
         print("%s - %s created." % (c.slug, c.title))
     return c
 
@@ -101,7 +101,7 @@ def create_coverage_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               protected_resources=json.dumps(pr, indent=4))
+                                               protected_resources=json.dumps(pr))
         print("%s - %s created." % (c.slug, c.title))
     return c
 

--- a/apps/capabilities/management/commands/create_fhir_starter_scopes.py
+++ b/apps/capabilities/management/commands/create_fhir_starter_scopes.py
@@ -57,7 +57,7 @@ def create_fhir_readonly_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               protected_resources=json.dumps(pr, indent=4))
+                                               protected_resources=json.dumps(pr))
         print("%s - %s created." % (c.slug, c.title))
     else:
         print("%s - %s skipped because it already existed." %

--- a/apps/fhir/bluebutton/opoutcome_utils.py
+++ b/apps/fhir/bluebutton/opoutcome_utils.py
@@ -27,7 +27,7 @@ def kickout_301(reason, status_code=301):
     response = OrderedDict()
     response['code'] = status_code
     response['errors'] = [reason]
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 
@@ -37,7 +37,7 @@ def kickout_302(reason, status_code=302):
     response = OrderedDict()
     response['code'] = status_code
     response['errors'] = [reason]
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 
@@ -52,7 +52,7 @@ def kickout_400(reason, status_code=400):
     issue['severity'] = 'fatal'
     issue['code'] = 'exception'
     issue['details'] = reason
-    return HttpResponse(json.dumps(oo, indent=4),
+    return HttpResponse(json.dumps(oo),
                         status=status_code,
                         content_type='application/json')
 
@@ -68,7 +68,7 @@ def kickout_401(reason, status_code=401):
     issue['code'] = 'security'
     issue['details'] = reason
     oo['issue'].append(issue)
-    return HttpResponse(json.dumps(oo, indent=4),
+    return HttpResponse(json.dumps(oo),
                         status=status_code,
                         content_type='application/json')
 
@@ -84,7 +84,7 @@ def kickout_402(reason, status_code=402):
     issue['code'] = 'security'
     issue['details'] = reason
     oo['issue'].append(issue)
-    return HttpResponse(json.dumps(oo, indent=4),
+    return HttpResponse(json.dumps(oo),
                         status=status_code,
                         content_type='application/json')
 
@@ -100,7 +100,7 @@ def kickout_403(reason, status_code=403):
     issue['code'] = 'security'
     issue['details'] = reason
     oo['issue'].append(issue)
-    return HttpResponse(json.dumps(oo, indent=4),
+    return HttpResponse(json.dumps(oo),
                         status=status_code,
                         content_type='application/json')
 
@@ -116,7 +116,7 @@ def kickout_404(reason, status_code=404):
     issue['code'] = 'not-found'
     issue['details'] = reason
     oo['issue'].append(issue)
-    return HttpResponse(json.dumps(oo, indent=4),
+    return HttpResponse(json.dumps(oo),
                         status=status_code,
                         content_type='application/json')
 
@@ -132,7 +132,7 @@ def kickout_500(reason, status_code=500):
     issue['code'] = 'exception'
     issue['details'] = reason
     oo['issue'].append(issue)
-    return HttpResponse(json.dumps(oo, indent=4),
+    return HttpResponse(json.dumps(oo),
                         status=status_code,
                         content_type='application/json')
 
@@ -142,7 +142,7 @@ def kickout_501(reason, status_code=501):
     response = OrderedDict()
     response['code'] = status_code
     response['errors'] = [reason, 'Not Implemented']
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 
@@ -152,7 +152,7 @@ def kickout_502(reason, status_code=502):
     response = OrderedDict()
     response['code'] = status_code
     response['errors'] = [reason, 'Bad Gateway']
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 
@@ -162,7 +162,7 @@ def kickout_503(reason, status_code=503):
     response = OrderedDict()
     response['code'] = status_code
     response['errors'] = [reason, 'Gateway Timeout']
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 
@@ -172,7 +172,7 @@ def kickout_504(reason, status_code=504):
     response = OrderedDict()
     response['code'] = status_code
     response['errors'] = [reason, 'Gateway Timeout']
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 
@@ -246,7 +246,7 @@ def error_status(r, status_code=404, reason='undefined error occurred'):
 
     logger.debug("Errors: %s" % response)
 
-    return HttpResponse(json.dumps(response, indent=4),
+    return HttpResponse(json.dumps(response),
                         status=status_code,
                         content_type='application/json')
 

--- a/apps/fhir/bluebutton/views/home.py
+++ b/apps/fhir/bluebutton/views/home.py
@@ -268,7 +268,7 @@ def metadata(request, via_oauth=False, *args, **kwargs):
             return render(
                 request,
                 'bluebutton/default.html',
-                {'output': pretty_json(r._content, indent=4),
+                {'output': pretty_json(r._content),
                  'fhir_id': get_fhir_id(cx),
                  'content': {'parameters': query_string,
                              'resource_type': resource_type,
@@ -278,7 +278,7 @@ def metadata(request, via_oauth=False, *args, **kwargs):
                              'div_texts': "",
                              'source': get_fhir_source_name(cx)}})
         else:
-            return HttpResponse(json.dumps(r._content, indent=4),
+            return HttpResponse(json.dumps(r._content),
                                 status=r.status_code,
                                 content_type='application/json')
 
@@ -362,10 +362,10 @@ def metadata(request, via_oauth=False, *args, **kwargs):
                                 content_type='application/'
                                              '%s' % requested_format)
         if 'security' in od:
-            print("%s" % pretty_json(od['security'], indent=4))
+            print("%s" % pretty_json(od['security']))
         else:
             print("No security content in Conformance")
-            print("od: %s" % pretty_json(od, indent=4))
+            print("od: %s" % pretty_json(od))
 
     # logger.debug('We got a different format:%s' % back_end_format)
 

--- a/apps/fhir/bluebutton/views/read.py
+++ b/apps/fhir/bluebutton/views/read.py
@@ -338,7 +338,7 @@ def generic_read(request,
             return render(
                 request,
                 'bluebutton/default.html',
-                {'output': pretty_json(r._content, indent=4),
+                {'output': pretty_json(r._content),
                  'fhir_id': get_fhir_id(cx),
                  'content': {'parameters': query_string,
                              'resource_type': resource_type,
@@ -348,7 +348,7 @@ def generic_read(request,
                              'div_texts': "",
                              'source': get_fhir_source_name(cx)}})
         else:
-            return HttpResponse(json.dumps(r._content, indent=4),
+            return HttpResponse(json.dumps(r._content),
                                 status=r.status_code,
                                 content_type='application/json')
 

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -416,7 +416,7 @@ def read_search(request,
             return render(
                 request,
                 'bluebutton/default.html',
-                {'output': pretty_json(r._content, indent=4),
+                {'output': pretty_json(r._content),
                  'fhir_id': get_fhir_id(cx),
                  'content': {'parameters': query_string,
                              'resource_type': resource_type,
@@ -426,7 +426,7 @@ def read_search(request,
                              'div_texts': "",
                              'source': get_fhir_source_name(cx)}})
         else:
-            return HttpResponse(json.dumps(r._content, indent=4),
+            return HttpResponse(json.dumps(r._content),
                                 status=r.status_code,
                                 content_type='application/json')
 


### PR DESCRIPTION
Currently, our JSON returns are indented according to pretty pringing standards. This change reduces our response size by as much as 70%